### PR TITLE
Add logfmt formatter

### DIFF
--- a/lib/cogger/formatters/logfmt.rb
+++ b/lib/cogger/formatters/logfmt.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "core"
+
+module Cogger
+  module Formatters
+    # Formats as JSON output.
+    class Logfmt
+      TEMPLATE = nil
+      WRAP_STRING_MATCHER = /[[:space:]]|[[:cntrl:]]/
+
+      def initialize template = TEMPLATE,
+                     parser: Parsers::Individual.new,
+                     sanitizer: Kit::Sanitizer
+        @positions = template ? parser.call(template).last.keys : Core::EMPTY_ARRAY
+        @sanitizer = sanitizer
+      end
+
+      def call(*input)
+        attributes = sanitizer.call(*input).tagged_attributes.tap(&:compact!)
+        unless positions.empty?
+          attributes = attributes.slice(*positions).merge!(attributes.except(*positions))
+        end
+
+        "#{attributes.map { |k, v| format_pair(k, v) }.join(" ")}\n"
+      end
+
+      private
+
+      attr_reader :positions, :sanitizer
+
+      # :reek:UtilityFunction
+      def format_date_time time
+        time.utc.strftime "%Y-%m-%dT%H:%M:%S.%L%:z"
+      end
+
+      # :reek:UtilityFunction
+      def format_pair key, value
+        "#{key}=#{format_value value}"
+      end
+
+      def format_value value
+        case value
+          when ::Time
+            format_date_time(value)
+          when ::Array
+            format_value(
+              "[#{value.map { |v| format_value(v) }.join(", ")}]"
+            )
+          else
+            # Interpolating for odd cases where #to_s does not return a String:
+            # https://github.com/ruby/spec/blob/3affe1e54fcd11918a242ad5d4a7ba895ee30c4c/language/string_spec.rb#L130-L141
+            value = "#{value}" # rubocop:disable Style/RedundantInterpolation
+
+            # wrap in quotes and escape control characters
+            value = value.dump if value.match? WRAP_STRING_MATCHER
+            value
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/cogger/formatters/logfmt_spec.rb
+++ b/spec/lib/cogger/formatters/logfmt_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Cogger::Formatters::Logfmt do
+  subject(:formatter) { described_class.new }
+
+  describe "#call" do
+    let(:at) { Time.now }
+    let(:at_formatted) { at.utc.strftime "%Y-%m-%dT%H:%M:%S.%L%:z" }
+
+    it "answers default template and message string" do
+      expect(formatter.call(Cogger::Entry.for("test", at:))).to eq(
+        %(id=rspec severity=INFO at=#{at_formatted} message=test\n)
+      )
+    end
+
+    it "wraps tag values with spaces or control characters in quotes" do
+      expect(formatter.call(Cogger::Entry.for("test message", control_character: "\t", at:))).to eq(
+        %(id=rspec severity=INFO at=#{at_formatted} message="test message" control_character="\\t"\n)
+      )
+    end
+
+    it "formats Time tag values" do
+      expect(formatter.call(Cogger::Entry.for(another_time: at, at:))).to eq(
+        %(id=rspec severity=INFO at=#{at_formatted} another_time=#{at_formatted}\n)
+      )
+    end
+
+    it "answers default template and message hash" do
+      expect(formatter.call(Cogger::Entry.for(at:, verb: "GET", path: "/"))).to eq(
+        %(id=rspec severity=INFO at=#{at_formatted} verb=GET path=/\n)
+      )
+    end
+
+    it "answers default template and no message" do
+      expect(formatter.call(Cogger::Entry.new(at:))).to eq(
+        %(id=rspec severity=INFO at=#{at_formatted}\n)
+      )
+    end
+
+    it "answers custom template and ordered message hash" do
+      formatter = described_class.new "%<path>s %<verb>s %<at>s %<severity>s %<id>s"
+
+      expect(formatter.call(Cogger::Entry.for(at:, verb: "GET", path: "/"))).to eq(
+        %(path=/ verb=GET at=#{at_formatted} severity=INFO id=rspec\n)
+      )
+    end
+
+    it "answers custom template and ordered metadata only" do
+      formatter = described_class.new "%<at>s %<id>s %<severity>s"
+
+      expect(formatter.call(Cogger::Entry.for(at:, verb: "GET", path: "/"))).to eq(
+        %(at=#{at_formatted} id=rspec severity=INFO verb=GET path=/\n)
+      )
+    end
+
+    it "answers custom template using invalid keys and message hash" do
+      formatter = described_class.new "%<one>s %<two>s %<three>s"
+
+      expect(formatter.call(Cogger::Entry.for(at:, verb: "GET", path: "/"))).to eq(
+        %(id=rspec severity=INFO at=#{at_formatted} verb=GET path=/\n)
+      )
+    end
+
+    it "answers with mixed tags" do
+      entry = Cogger::Entry.for at:,
+                                message: "test",
+                                path: "/",
+                                tags: ["ONE", :TWO, {three: 3, four: 4}]
+
+      proof = %W[
+        id=rspec
+        severity=INFO
+        at=#{at_formatted}
+        message=test
+        tags="[ONE, TWO]"
+        three=3
+        four=4
+        path=/
+      ].join(" ")
+
+      expect(formatter.call(entry)).to eq(%(#{proof}\n))
+    end
+  end
+end


### PR DESCRIPTION
## Overview
This implements a new formatter for [logfmt](https://brandur.org/logfmt) style logs. It is aligned with existing formatter implementations - my first pass started as a copy of the json formatter. This offers another formatting option that could be a replacement for the [logfmt](https://rubygems.org/gems/logfmt) gem.

## Screenshots/Screencasts
WIP
<!-- Optional. Provide supporting image/video. -->

## Details
The essence of this format is that it is a structured log that is fairly human-readable and prints to one line. It offers formatting for:
* Time
* Array
* Strings with spaces or control characters
* String-interpolates other object types

## Not yet resolved
* [x] git lint doesn't like my commit message `Commit Subject Prefix Error. Use: /Fixed /, /Added /, /Updated /, /Removed /, or /Refactored /.`
* [ ] Rubocop doesn't like some stuff, and I don't like some of the fixes
* [ ] I think there's some reek stuff to wrangle
* [ ] Might be worth revisiting some of the stuff that is roughly copied from the json formatter (and specs)
* [ ] I know the `logfmt` gem has some niceties that do things like justify the severity values (so that things like `info` and `error` line up). Worth considering adding to this
* [ ] The `logfmt` gem can parse this format. 1) does cogger implement deserializers? 2) I never validated that cogger's logfmt parses correctly
* [ ] Look at this again when I'm not sleep-deprived (lol)
